### PR TITLE
refactor: migrate from ES modules to CommonJS for better compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,37 +1,7 @@
-class WorkflowManager {
-  constructor(plugin) {
-    this.plugin = plugin;
-  }
-
-  validateWorkflowConfigurations(workflows) {
-    if (!workflows || Object.keys(workflows).length === 0) {
-      this.plugin.serverless.cli.log('No Glue Workflows configurations found.');
-      return;
-    }
-  }
-}
-
-class CrawlerManager {
-  constructor(plugin) {
-    this.plugin = plugin;
-  }
-}
-
-class JobManager {
-  constructor(plugin) {
-    this.plugin = plugin;
-  }
-}
-
-class ResourceGenerator {
-  constructor(plugin) {
-    this.plugin = plugin;
-  }
-
-  prepareWorkflowResources(workflows) {
-    // Implementation will be added later
-  }
-}
+const WorkflowManager = require('./src/lib/workflow-manager');
+const CrawlerManager = require('./src/lib/crawler-manager');
+const JobManager = require('./src/lib/job-manager');
+const ResourceGenerator = require('./src/lib/resource-generator');
 
 class ServerlessAWSGlueWorkflows {
   constructor(serverless, options) {
@@ -73,4 +43,4 @@ class ServerlessAWSGlueWorkflows {
   }
 }
 
-module.exports = ServerlessAWSGlueWorkflows; 
+module.exports = ServerlessAWSGlueWorkflows;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "serverless-aws-glue-workflows",
-  "version": "0.0.9",
-  "description": "A Sererless Framework plugin to add support for managing AWS Glue Workflows, simplifying the integration and deployment of ETL workflows in AWS.",
+  "version": "0.0.10",
+  "description": "A Serverless Framework plugin to add support for managing AWS Glue Workflows, simplifying the integration and deployment of ETL workflows in AWS.",
   "main": "index.js",
   "publishConfig": {
     "access": "public"
@@ -9,10 +9,22 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "keywords": [],
+  "keywords": [
+    "serverless",
+    "aws",
+    "glue",
+    "workflow",
+    "etl"
+  ],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "serverless": "^4.4.18"
+    "serverless": "^3.38.0"
+  },
+  "peerDependencies": {
+    "serverless": "^3.0.0"
+  },
+  "dependencies": {
+    "debug": "^4.3.4"
   }
 }

--- a/src/lib/crawler-manager.js
+++ b/src/lib/crawler-manager.js
@@ -74,4 +74,4 @@ class CrawlerManager {
   }
 }
 
-export default CrawlerManager;
+module.exports = CrawlerManager;

--- a/src/lib/debug.js
+++ b/src/lib/debug.js
@@ -1,0 +1,11 @@
+const debug = require('debug');
+
+const debugLog = {
+  main: debug('serverless-aws-glue:main'),
+  workflow: debug('serverless-aws-glue:workflow'),
+  job: debug('serverless-aws-glue:job'),
+  crawler: debug('serverless-aws-glue:crawler'),
+  resource: debug('serverless-aws-glue:resource')
+};
+
+module.exports = debugLog;

--- a/src/lib/job-manager.js
+++ b/src/lib/job-manager.js
@@ -74,4 +74,4 @@ class JobManager {
   }
 }
 
-export default JobManager;
+module.exports = JobManager;

--- a/src/lib/resource-generator.js
+++ b/src/lib/resource-generator.js
@@ -6,6 +6,9 @@ class ResourceGenerator {
   prepareWorkflowResources(workflows) {
     if (!workflows || Object.keys(workflows).length === 0) return;
 
+    // Add debugging
+    this.plugin.serverless.cli.log(`Adding resources for workflows: ${Object.keys(workflows).join(', ')}`);
+
     const resources = this.plugin.service.resources = this.plugin.service.resources || {};
     resources.Resources = resources.Resources || {};
 
@@ -29,6 +32,9 @@ class ResourceGenerator {
       // Add jobs and triggers resources
       this.plugin.jobManager.addJobsToResources(workflowName, workflow, resources.Resources);
     }
+
+    // Add more debugging
+    this.plugin.serverless.cli.log(`Total resources added: ${Object.keys(resources.Resources).length}`);
   }
 
   getWorkflowLogicalId(workflowName) {
@@ -40,4 +46,4 @@ class ResourceGenerator {
   }
 }
 
-export default ResourceGenerator;
+module.exports = ResourceGenerator;

--- a/src/lib/workflow-manager.js
+++ b/src/lib/workflow-manager.js
@@ -46,4 +46,4 @@ class WorkflowManager {
   }
 }
 
-export default WorkflowManager;
+module.exports = WorkflowManager;


### PR DESCRIPTION
This commit transitions the codebase from ES modules to CommonJS by replacing `export default` with `module.exports`. This change improves compatibility with the Serverless Framework and Node.js environments. Additionally, a new debug utility is introduced for better logging, and the package.json is updated to include relevant keywords and dependencies.