### PR TITLE
feat(job-manager): add support for on-demand job triggers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,19 @@
 {
   "name": "serverless-aws-glue-workflows",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "A Serverless Framework plugin to add support for managing AWS Glue Workflows, simplifying the integration and deployment of ETL workflows in AWS.",
   "main": "index.js",
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lucasventura99/serverless-aws-glue-workflows.git"
+  },
+  "bugs": {
+    "url": "https://github.com/lucasventura99/serverless-aws-glue-workflows/issues"
+  },
+  "homepage": "https://github.com/lucasventura99/serverless-aws-glue-workflows#readme",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Introduce a new trigger type option (`triggerType`) for job triggers, allowing users to specify either `CONDITIONAL` (default) or `ON_DEMAND`. This enhances flexibility in managing AWS Glue workflows by enabling immediate job execution without dependency on previous job states. Additionally, update package.json to include repository, bugs, and homepage URLs for better project visibility and issue tracking.