### PR TITLE
fix(crawler-manager): change trigger type to ON_DEMAND for crawler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-aws-glue-workflows",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "A Serverless Framework plugin to add support for managing AWS Glue Workflows, simplifying the integration and deployment of ETL workflows in AWS.",
   "main": "index.js",
   "publishConfig": {

--- a/src/lib/crawler-manager.js
+++ b/src/lib/crawler-manager.js
@@ -6,15 +6,22 @@ class CrawlerManager {
   addCrawlersToResources(workflowName, workflow, resources) {
     if (!workflow.crawlers) return;
 
-    this.plugin.serverless.cli.log(`Adding ${workflow.crawlers.length} crawlers for workflow: ${workflowName}`);
-    
+    this.plugin.serverless.cli.log(
+      `Adding ${workflow.crawlers.length} crawlers for workflow: ${workflowName}`
+    );
+
     workflow.crawlers.forEach((crawler, index) => {
-      const crawlerLogicalId = this.getCrawlerLogicalId(workflowName, crawler.name);
-      
-      this.plugin.serverless.cli.log(`Creating crawler resource: ${crawler.name} (${crawlerLogicalId})`);
-      
+      const crawlerLogicalId = this.getCrawlerLogicalId(
+        workflowName,
+        crawler.name
+      );
+
+      this.plugin.serverless.cli.log(
+        `Creating crawler resource: ${crawler.name} (${crawlerLogicalId})`
+      );
+
       resources[crawlerLogicalId] = {
-        Type: 'AWS::Glue::Crawler',
+        Type: "AWS::Glue::Crawler",
         Properties: {
           Name: crawler.name,
           Role: crawler.role,
@@ -22,61 +29,70 @@ class CrawlerManager {
           Targets: crawler.targets,
           Schedule: crawler.schedule,
           SchemaChangePolicy: crawler.schemaChangePolicy || {
-            UpdateBehavior: 'UPDATE_IN_DATABASE',
-            DeleteBehavior: 'DEPRECATE_IN_DATABASE'
+            UpdateBehavior: "UPDATE_IN_DATABASE",
+            DeleteBehavior: "DEPRECATE_IN_DATABASE",
           },
           Configuration: crawler.configuration || {},
           CrawlerSecurityConfiguration: crawler.securityConfiguration,
-          Tags: crawler.tags || {}
-        }
+          Tags: crawler.tags || {},
+        },
       };
 
-      // Add trigger for crawler if it's the first crawler and there are jobs
       if (index === 0 && workflow.jobs && workflow.jobs.length > 0) {
-        // Check if we should skip auto-triggers based on configuration
         if (workflow.skipCrawlerTriggers !== true) {
           this.addCrawlerTrigger(workflowName, crawler, resources);
         } else {
-          this.plugin.serverless.cli.log(`Skipping auto-trigger for crawler: ${crawler.name} (skipCrawlerTriggers is true)`);
+          this.plugin.serverless.cli.log(
+            `Skipping auto-trigger for crawler: ${crawler.name} (skipCrawlerTriggers is true)`
+          );
         }
       }
     });
   }
 
   addCrawlerTrigger(workflowName, crawler, resources) {
-    const triggerLogicalId = this.getTriggerLogicalId(workflowName, crawler.name);
-    const crawlerLogicalId = this.getCrawlerLogicalId(workflowName, crawler.name);
+    const triggerLogicalId = this.getTriggerLogicalId(
+      workflowName,
+      crawler.name
+    );
+    const crawlerLogicalId = this.getCrawlerLogicalId(
+      workflowName,
+      crawler.name
+    );
 
-    this.plugin.serverless.cli.log(`Creating crawler trigger: ${triggerLogicalId} for crawler: ${crawler.name}`);
-    
+    this.plugin.serverless.cli.log(
+      `Creating crawler trigger: ${triggerLogicalId} for crawler: ${crawler.name}`
+    );
+
     resources[triggerLogicalId] = {
-      Type: 'AWS::Glue::Trigger',
+      Type: "AWS::Glue::Trigger",
       Properties: {
         Name: `${workflowName}-${crawler.name}-trigger`,
-        Type: 'CONDITIONAL',
+        Type: "ON_DEMAND",
         WorkflowName: { Ref: this.getWorkflowLogicalId(workflowName) },
-        Actions: [{
-          CrawlerName: { Ref: crawlerLogicalId }
-        }],
-        Predicate: {
-          Logical: 'AND', // Add the missing Logical operator
-          Conditions: [{
+        Actions: [
+          {
             CrawlerName: { Ref: crawlerLogicalId },
-            CrawlState: 'SUCCEEDED'
-          }]
-        }
-      }
+          },
+        ],
+      },
     };
-    
-    this.plugin.serverless.cli.log(`Crawler trigger created with predicate: ${JSON.stringify(resources[triggerLogicalId].Properties.Predicate)}`);
+
+    this.plugin.serverless.cli.log(
+      `Crawler trigger created as ON_DEMAND trigger for crawler: ${crawler.name}`
+    );
   }
 
   getCrawlerLogicalId(workflowName, crawlerName) {
-    return `GlueCrawler${this.normalizeResourceId(workflowName)}${this.normalizeResourceId(crawlerName)}`;
+    return `GlueCrawler${this.normalizeResourceId(
+      workflowName
+    )}${this.normalizeResourceId(crawlerName)}`;
   }
 
   getTriggerLogicalId(workflowName, resourceName) {
-    return `GlueTrigger${this.normalizeResourceId(workflowName)}${this.normalizeResourceId(resourceName)}`;
+    return `GlueTrigger${this.normalizeResourceId(
+      workflowName
+    )}${this.normalizeResourceId(resourceName)}`;
   }
 
   getWorkflowLogicalId(workflowName) {
@@ -84,7 +100,7 @@ class CrawlerManager {
   }
 
   normalizeResourceId(str) {
-    return str.replace(/[^a-zA-Z0-9]/g, '');
+    return str.replace(/[^a-zA-Z0-9]/g, "");
   }
 }
 


### PR DESCRIPTION
The trigger type for crawlers was updated from CONDITIONAL to ON_DEMAND to simplify the triggering mechanism and avoid unnecessary conditions. This change ensures that crawlers are triggered directly without waiting for specific conditions to be met.