### PR TITLE
feat(crawler-manager): add trigger to connect crawler to first job

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-aws-glue-workflows",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "A Serverless Framework plugin to add support for managing AWS Glue Workflows, simplifying the integration and deployment of ETL workflows in AWS.",
   "main": "index.js",
   "publishConfig": {


### PR DESCRIPTION
Add a new method `addCrawlerToJobTrigger` to create a conditional trigger that connects a crawler to the first job in a workflow. This ensures the job is triggered automatically after the crawler completes successfully. Also, increment the package version to 0.0.16.