### PR TITLE
refactor(crawler-manager): simplify CrawlerName reference syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-aws-glue-workflows",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "A Serverless Framework plugin to add support for managing AWS Glue Workflows, simplifying the integration and deployment of ETL workflows in AWS.",
   "main": "index.js",
   "publishConfig": {

--- a/src/lib/crawler-manager.js
+++ b/src/lib/crawler-manager.js
@@ -76,7 +76,7 @@ class CrawlerManager {
         WorkflowName: { Ref: this.getWorkflowLogicalId(workflowName) },
         Actions: [
           {
-            CrawlerName: { Ref: crawlerLogicalId },
+            CrawlerName: crawlerLogicalId,
           },
         ],
       },


### PR DESCRIPTION
Removed the unnecessary `Ref` wrapper around `crawlerLogicalId` to streamline the code and improve readability