### PR TITLE
refactor: simplify workflow trigger resource references

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-aws-glue-workflows",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "description": "A Serverless Framework plugin to add support for managing AWS Glue Workflows, simplifying the integration and deployment of ETL workflows in AWS.",
   "main": "index.js",
   "publishConfig": {

--- a/src/lib/crawler-manager.js
+++ b/src/lib/crawler-manager.js
@@ -40,11 +40,14 @@ class CrawlerManager {
 
       if (index === 0 && workflow.jobs && workflow.jobs.length > 0) {
         if (workflow.skipCrawlerTriggers !== true) {
-          // Create the crawler trigger
           this.addCrawlerTrigger(workflowName, crawler, resources);
-          
-          // Create a trigger to connect the crawler to the first job
-          this.addCrawlerToJobTrigger(workflowName, crawler, workflow.jobs[0], resources);
+
+          this.addCrawlerToJobTrigger(
+            workflowName,
+            crawler,
+            workflow.jobs[0],
+            resources
+          );
         } else {
           this.plugin.serverless.cli.log(
             `Skipping auto-trigger for crawler: ${crawler.name} (skipCrawlerTriggers is true)`
@@ -73,7 +76,7 @@ class CrawlerManager {
       Properties: {
         Name: `${workflowName}-${crawler.name}-trigger`,
         Type: "ON_DEMAND",
-        WorkflowName: { Ref: this.getWorkflowLogicalId(workflowName) },
+        WorkflowName: this.getWorkflowLogicalId(workflowName),
         Actions: [
           {
             CrawlerName: crawlerLogicalId,
@@ -88,9 +91,18 @@ class CrawlerManager {
   }
 
   addCrawlerToJobTrigger(workflowName, crawler, job, resources) {
-    const triggerLogicalId = `GlueTrigger${this.normalizeResourceId(workflowName)}${this.normalizeResourceId(crawler.name)}ToJob${this.normalizeResourceId(job.name)}`;
-    const crawlerLogicalId = this.getCrawlerLogicalId(workflowName, crawler.name);
-    const jobLogicalId = `GlueJob${this.normalizeResourceId(workflowName)}${this.normalizeResourceId(job.name)}`;
+    const triggerLogicalId = `GlueTrigger${this.normalizeResourceId(
+      workflowName
+    )}${this.normalizeResourceId(crawler.name)}ToJob${this.normalizeResourceId(
+      job.name
+    )}`;
+    const crawlerLogicalId = this.getCrawlerLogicalId(
+      workflowName,
+      crawler.name
+    );
+    const jobLogicalId = `GlueJob${this.normalizeResourceId(
+      workflowName
+    )}${this.normalizeResourceId(job.name)}`;
 
     this.plugin.serverless.cli.log(
       `Creating crawler-to-job trigger: ${triggerLogicalId} from crawler: ${crawler.name} to job: ${job.name}`
@@ -101,17 +113,17 @@ class CrawlerManager {
       Properties: {
         Name: `${workflowName}-${crawler.name}-to-${job.name}-trigger`,
         Type: "CONDITIONAL",
-        WorkflowName: { Ref: this.getWorkflowLogicalId(workflowName) },
+        WorkflowName:this.getWorkflowLogicalId(workflowName),
         Actions: [
           {
-            JobName: { Ref: jobLogicalId },
+            JobName:jobLogicalId,
           },
         ],
         Predicate: {
           Logical: "AND",
           Conditions: [
             {
-              CrawlerName: { Ref: crawlerLogicalId },
+              CrawlerName: crawlerLogicalId,
               CrawlState: "SUCCEEDED",
             },
           ],

--- a/src/lib/job-manager.js
+++ b/src/lib/job-manager.js
@@ -62,10 +62,10 @@ class JobManager {
       Properties: {
         Name: `${workflowName}-${job.name}-trigger`,
         Type: triggerType,
-        WorkflowName: { Ref: this.getWorkflowLogicalId(workflowName) },
+        WorkflowName: this.getWorkflowLogicalId(workflowName),
         Actions: [
           {
-            JobName: { Ref: jobLogicalId },
+            JobName: jobLogicalId,
           },
         ],
       },
@@ -100,8 +100,9 @@ class JobManager {
         ];
       }
 
-      const logicalOperator = job.logical && job.logical.trim() ? job.logical.trim() : "AND";
-      
+      const logicalOperator =
+        job.logical && job.logical.trim() ? job.logical.trim() : "AND";
+
       triggerResource.Properties.Predicate = {
         Logical: logicalOperator,
         Conditions: conditions,


### PR DESCRIPTION
Remove unnecessary `{ Ref: ... }` wrapping around workflow, job, and crawler references in trigger resources. This improves code readability and consistency. Also, format logical operator assignment for better clarity.