### PR TITLE
refactor: update workflow triggers to use { Ref } syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-aws-glue-workflows",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "A Serverless Framework plugin to add support for managing AWS Glue Workflows, simplifying the integration and deployment of ETL workflows in AWS.",
   "main": "index.js",
   "publishConfig": {

--- a/src/lib/crawler-manager.js
+++ b/src/lib/crawler-manager.js
@@ -76,10 +76,10 @@ class CrawlerManager {
       Properties: {
         Name: `${workflowName}-${crawler.name}-trigger`,
         Type: "ON_DEMAND",
-        WorkflowName: this.getWorkflowLogicalId(workflowName),
+        WorkflowName: { Ref: this.getWorkflowLogicalId(workflowName) },
         Actions: [
           {
-            CrawlerName: crawlerLogicalId,
+            CrawlerName: { Ref: crawlerLogicalId },
           },
         ],
       },
@@ -113,17 +113,17 @@ class CrawlerManager {
       Properties: {
         Name: `${workflowName}-${crawler.name}-to-${job.name}-trigger`,
         Type: "CONDITIONAL",
-        WorkflowName:this.getWorkflowLogicalId(workflowName),
+        WorkflowName: { Ref: this.getWorkflowLogicalId(workflowName) },
         Actions: [
           {
-            JobName:jobLogicalId,
+            JobName: { Ref: jobLogicalId },
           },
         ],
         Predicate: {
           Logical: "AND",
           Conditions: [
             {
-              CrawlerName: crawlerLogicalId,
+              CrawlerName: { Ref: crawlerLogicalId },
               CrawlState: "SUCCEEDED",
             },
           ],


### PR DESCRIPTION
Modify the workflow trigger properties in CrawlerManager to use the { Ref } syntax for referencing resources. This change aligns with AWS CloudFormation best practices, ensuring proper resource referencing and avoiding potential issues during deployment. Additionally, the package version is incremented to reflect these updates.