### PR TITLE
fix(job-manager): update trigger resource properties to use Ref and a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-aws-glue-workflows",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "A Serverless Framework plugin to add support for managing AWS Glue Workflows, simplifying the integration and deployment of ETL workflows in AWS.",
   "main": "index.js",
   "publishConfig": {

--- a/src/lib/job-manager.js
+++ b/src/lib/job-manager.js
@@ -62,10 +62,10 @@ class JobManager {
       Properties: {
         Name: `${workflowName}-${job.name}-trigger`,
         Type: triggerType,
-        WorkflowName: this.getWorkflowLogicalId(workflowName),
+        WorkflowName: { Ref: this.getWorkflowLogicalId(workflowName) },
         Actions: [
           {
-            JobName: jobLogicalId,
+            JobName: { Ref: jobLogicalId },
           },
         ],
       },
@@ -104,6 +104,7 @@ class JobManager {
         job.logical && job.logical.trim() ? job.logical.trim() : "AND";
 
       triggerResource.Properties.Predicate = {
+        LogicalOperator: "EQUALS",
         Logical: logicalOperator,
         Conditions: conditions,
       };


### PR DESCRIPTION
…dd LogicalOperator

Update the trigger resource properties in JobManager to use `Ref` for WorkflowName and JobName, ensuring correct referencing. Additionally, add the `LogicalOperator` property to the Predicate object to align with AWS Glue's expected schema.