### PR TITLE
fix(job-manager): correct LogicalOperator placement in job conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-aws-glue-workflows",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "A Serverless Framework plugin to add support for managing AWS Glue Workflows, simplifying the integration and deployment of ETL workflows in AWS.",
   "main": "index.js",
   "publishConfig": {

--- a/src/lib/job-manager.js
+++ b/src/lib/job-manager.js
@@ -82,6 +82,7 @@ class JobManager {
           if (condition.JobName && !condition.JobName.Ref) {
             return {
               ...condition,
+              LogicalOperator: "EQUALS",
               JobName: {
                 Ref: this.getJobLogicalId(workflowName, condition.JobName),
               },
@@ -104,7 +105,6 @@ class JobManager {
         job.logical && job.logical.trim() ? job.logical.trim() : "AND";
 
       triggerResource.Properties.Predicate = {
-        LogicalOperator: "EQUALS",
         Logical: logicalOperator,
         Conditions: conditions,
       };


### PR DESCRIPTION
The LogicalOperator was incorrectly placed in the triggerResource.Properties.Predicate object instead of within each condition. This commit moves the LogicalOperator to the correct location within the condition object to ensure proper job condition evaluation.